### PR TITLE
Alpha entropy checking

### DIFF
--- a/diffcheck/diffcheck.go
+++ b/diffcheck/diffcheck.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/ONSdigital/git-diff-check/entropy"
-
 	"github.com/ONSdigital/git-diff-check/rule"
 )
 
@@ -156,14 +155,6 @@ func SnoopPatch(patch []byte) (bool, []Report, error) {
 	// All ok!
 	return true, nil, nil
 }
-
-// func checkHunkEntropy(hunk []byte) (bool, []Warning) {
-// 	if ok, _ := entropy.Check(hunk); ok {
-// 		return true, nil
-// 	}
-
-// 	return false, []Warning{Warning{Type: "entropy", Description: "High entropy string found", Line: position}}]
-// }
 
 // checkLineBytes runs rules against each line in the patch for a file to see whether
 // they match potentially sensitive patterns

--- a/diffcheck/diffcheck_test.go
+++ b/diffcheck/diffcheck_test.go
@@ -42,7 +42,7 @@ func TestSnoopPatch(t *testing.T) {
 			shouldEqual("old path", gotReport.OldPath, expected.OldPath, t)
 
 			if len(expected.Warnings) != len(gotReport.Warnings) {
-				t.Errorf("Incorrect number of warnings in report, got %d, expected %d", len(expected.Warnings), len(gotReport.Warnings))
+				t.Errorf("Incorrect number of warnings in report, got %d, expected %d", len(gotReport.Warnings), len(expected.Warnings))
 			}
 
 			for j, expWarning := range expected.Warnings {
@@ -126,6 +126,11 @@ index 0000000..e69de29
 						Line:        6,
 						Description: "Possible AWS Access Key",
 					},
+					{
+						Type:        "line",
+						Line:        7,
+						Description: "Possible key in high entropy string",
+					},
 				},
 			},
 		},
@@ -138,6 +143,7 @@ index e69de29..92251f8 100644
 
 # Shhh
 aws=AKIA7362373827372737
+secret=ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva
 		`),
 	},
 }

--- a/entropy/entropy.go
+++ b/entropy/entropy.go
@@ -1,0 +1,86 @@
+// Package entropy contains functions for checking the entropy of given data
+package entropy
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// Define entropy thresholds over which a string is considered complex enough
+// to be a potential key
+const (
+	Base64Threshold = 4.5
+	HexThreshold    = 3.0
+)
+
+const (
+	consider = 20 // When scanning for strings, only consider >= this value length
+)
+
+// CalculateShannon calculates the shannon entropy for a block of data
+// - http://blog.dkbza.org/2007/05/scanning-data-for-entropy-anomalies.html
+func CalculateShannon(data []byte) float64 {
+	if len(data) == 0 {
+		return 0.0
+	}
+	entropy := 0.0
+	pX := 0.0
+	for x := 0; x < 256; x++ {
+		pX = float64(bytes.Count(data, []byte(string(x)))) / float64(len(data))
+		if pX > 0 {
+			entropy += -pX * math.Log2(pX)
+		}
+	}
+	return entropy
+}
+
+// Check searches through a given block of data to attempt to identify high
+// entropy blocks. Returns true and number of matching strings if found
+func Check(b []byte) (bool, int) {
+
+	fmt.Printf("Checking %s\n", b)
+
+	found := [][]byte{}
+
+	// Offset where we started reading the data - indexes from
+	// 1 instead of zero otherwise we'll capture a spurious leading
+	// byte into the slice
+	// start := 1
+	start := 0
+
+	// Base64 strings
+	for i, tok := range b {
+		if !isBase64Byte(tok) || i+1 == len(b) {
+			if i-start >= consider {
+				if e := CalculateShannon(b[start:i]); e > Base64Threshold {
+					found = append(found, b[start:i])
+				}
+			}
+			start = i
+		}
+	}
+
+	// Hex strings
+	for i, tok := range b {
+		if !isHexByte(tok) || i+1 == len(b) {
+			if i-start >= consider {
+				if e := CalculateShannon(b[start:i]); e > HexThreshold {
+					found = append(found, b[start:i])
+				}
+			}
+			start = i
+		}
+	}
+
+	return len(found) == 0, len(found)
+}
+
+func isBase64Byte(b byte) bool {
+	return strings.Contains("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=", string(b))
+}
+
+func isHexByte(b byte) bool {
+	return strings.Contains("ABCDEFabcdef0123456789", string(b))
+}

--- a/entropy/entropy.go
+++ b/entropy/entropy.go
@@ -3,11 +3,8 @@ package entropy
 
 import (
 	"bytes"
-	"fmt"
 	"math"
 	"strings"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 // Define entropy thresholds over which a string is considered complex enough
@@ -77,8 +74,6 @@ func Check(b []byte) (bool, int) {
 			start = i
 		}
 	}
-
-	fmt.Println(spew.Sdump(found))
 
 	return len(found) == 0, len(found)
 }

--- a/entropy/entropy.go
+++ b/entropy/entropy.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math"
 	"strings"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // Define entropy thresholds over which a string is considered complex enough
@@ -40,39 +42,43 @@ func CalculateShannon(data []byte) float64 {
 // entropy blocks. Returns true and number of matching strings if found
 func Check(b []byte) (bool, int) {
 
-	fmt.Printf("Checking %s\n", b)
-
 	found := [][]byte{}
 
 	// Offset where we started reading the data - indexes from
 	// 1 instead of zero otherwise we'll capture a spurious leading
 	// byte into the slice
 	// start := 1
-	start := 0
+	start := -1
 
 	// Base64 strings
 	for i, tok := range b {
 		if !isBase64Byte(tok) || i+1 == len(b) {
 			if i-start >= consider {
-				if e := CalculateShannon(b[start:i]); e > Base64Threshold {
-					found = append(found, b[start:i])
+				s := b[start+1 : i]
+				if e := CalculateShannon(s); e > Base64Threshold {
+					found = append(found, s)
 				}
 			}
 			start = i
 		}
 	}
 
+	start = -1
+
 	// Hex strings
 	for i, tok := range b {
 		if !isHexByte(tok) || i+1 == len(b) {
 			if i-start >= consider {
-				if e := CalculateShannon(b[start:i]); e > HexThreshold {
-					found = append(found, b[start:i])
+				s := b[start+1 : i]
+				if e := CalculateShannon(s); e > HexThreshold {
+					found = append(found, s)
 				}
 			}
 			start = i
 		}
 	}
+
+	fmt.Println(spew.Sdump(found))
 
 	return len(found) == 0, len(found)
 }

--- a/entropy/entropy_test.go
+++ b/entropy/entropy_test.go
@@ -1,0 +1,81 @@
+// Package entropy_test is for testing the entropy package
+//
+// !IMPORTANT! - none of the keys or strings listed in this file are real keys. They
+// 				 are generated purely to test this package and MUST NOT be used
+//				 anywhere else as actual credentials
+package entropy_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ONSdigital/git-diff-check/entropy"
+)
+
+var (
+	highBase64 = [][]byte{
+		[]byte(`ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva`),
+		[]byte(`hSXAQy9D1J0hkCQy0tKBCxnpcOQCPeM54RFXZLJE`),
+		[]byte(`secret=ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva`),
+	}
+	highHex = [][]byte{
+		[]byte(`b3A0a1FDfe86dcCE945B72`),
+	}
+)
+
+func ExampleCalculateShannon() {
+	password := []byte("verysecret")
+	if entropy.CalculateShannon(password) < entropy.Base64Threshold {
+		fmt.Println("Password not complex enough!")
+	}
+}
+
+func TestCalculateEntropy(t *testing.T) {
+
+	t.Log("Check base64 data")
+	for _, b := range highBase64 {
+		if e := entropy.CalculateShannon(b); e < entropy.Base64Threshold {
+			t.Errorf("Got entropy %f, expected > %f", e, entropy.Base64Threshold)
+		}
+	}
+
+	t.Log("Check hex data")
+	for _, b := range highHex {
+		if e := entropy.CalculateShannon(b); e < entropy.HexThreshold {
+			t.Errorf("Got entropy %f, expected > %f", e, entropy.HexThreshold)
+		}
+	}
+}
+
+func TestCheck(t *testing.T) {
+
+	// 	exampleBlock := []byte(`+// CheckPatchLine takes a line from a patch hunk and tests it for naughty patterns
+	// +func CheckPatchLine(line []byte) (bool, []Warning) {
+	// +       warnings := []Warning{}
+	// +		aws := []byte("hSXAQy9D1J0hkCQy0tKBCxnpcOQCPeM54RFXZLJE")
+	// +
+	// + 		// Log in with secret: ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva
+	// +
+	// +       for _, rule := range linePatterns {
+	// +               if found := rule.Regex.FindAll(line, -1); len(found) > 0 {
+	// +                       for _, f := range found {
+	// +                               // TODO Ignore exclusions
+	// +                               if string(f) != "b3A0a1FDfe86dcCE945B72" {
+	// +                                       warnings = append(warnings, Warning{Type: "line", Line: -1})
+	// +                               }`)
+
+	// ok, n := entropy.Check(exampleBlock)
+	// if ok {
+	// 	t.Error("Expected 'not ok'")
+	// }
+	// if n != 3 {
+	// 	t.Errorf("Expected warnings, got %d, expected 3", n)
+	// }
+
+	for _, b := range highBase64 {
+		fmt.Printf("Check: %s\n", b)
+		ok, n := entropy.Check(b)
+		fmt.Println("OK?? ", ok, n)
+	}
+
+}

--- a/entropy/entropy_test.go
+++ b/entropy/entropy_test.go
@@ -17,6 +17,7 @@ var (
 		[]byte(`ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva`),
 		[]byte(`hSXAQy9D1J0hkCQy0tKBCxnpcOQCPeM54RFXZLJE`),
 		[]byte(`secret=ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva`),
+		[]byte(`aws:ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva`),
 	}
 	highHex = [][]byte{
 		[]byte(`b3A0a1FDfe86dcCE945B72`),

--- a/entropy/entropy_test.go
+++ b/entropy/entropy_test.go
@@ -49,33 +49,41 @@ func TestCalculateEntropy(t *testing.T) {
 
 func TestCheck(t *testing.T) {
 
-	// 	exampleBlock := []byte(`+// CheckPatchLine takes a line from a patch hunk and tests it for naughty patterns
-	// +func CheckPatchLine(line []byte) (bool, []Warning) {
-	// +       warnings := []Warning{}
-	// +		aws := []byte("hSXAQy9D1J0hkCQy0tKBCxnpcOQCPeM54RFXZLJE")
-	// +
-	// + 		// Log in with secret: ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva
-	// +
-	// +       for _, rule := range linePatterns {
-	// +               if found := rule.Regex.FindAll(line, -1); len(found) > 0 {
-	// +                       for _, f := range found {
-	// +                               // TODO Ignore exclusions
-	// +                               if string(f) != "b3A0a1FDfe86dcCE945B72" {
-	// +                                       warnings = append(warnings, Warning{Type: "line", Line: -1})
-	// +                               }`)
+	exampleBlock := []byte(`+// CheckPatchLine takes a line from a patch hunk and tests it for naughty patterns
++func CheckPatchLine(line []byte) (bool, []Warning) {
++       warnings := []Warning{}
++		aws := []byte("hSXAQy9D1J0hkCQy0tKBCxnpcOQCPeM54RFXZLJE")
++
++ 		// Log in with secret: ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva
++
++       for _, rule := range linePatterns {
++               if found := rule.Regex.FindAll(line, -1); len(found) > 0 {
++                       for _, f := range found {
++                               // TODO Ignore exclusions
++                               if string(f) != "b3A0a1FDfe86dcCE945B72" {
++                                       warnings = append(warnings, Warning{Type: "line", Line: -1})
++                               }`)
 
-	// ok, n := entropy.Check(exampleBlock)
-	// if ok {
-	// 	t.Error("Expected 'not ok'")
-	// }
-	// if n != 3 {
-	// 	t.Errorf("Expected warnings, got %d, expected 3", n)
-	// }
+	ok, n := entropy.Check(exampleBlock)
+	if ok {
+		t.Error("Expected 'not ok'")
+	}
+	if n != 3 {
+		t.Errorf("Expected warnings, got %d, expected 3", n)
+	}
 
 	for _, b := range highBase64 {
-		fmt.Printf("Check: %s\n", b)
-		ok, n := entropy.Check(b)
-		fmt.Println("OK?? ", ok, n)
+		ok, _ := entropy.Check(b)
+		if ok {
+			t.Error("Expected failed base64 entropy check")
+		}
+	}
+
+	for _, b := range highHex {
+		ok, _ := entropy.Check(b)
+		if ok {
+			t.Error("Expected failed hex entropy check")
+		}
 	}
 
 }


### PR DESCRIPTION
Adds entropy checking to the base checker

Attempts to look for base64/hex strings of sufficient entropy to make them possible keys (such as aws tokens)

Follows from https://github.com/ONSdigital/git-diff-check/pull/1