### PR TITLE
Fix #8 ignore lines being removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix #8 ignore lines in a patch that are being removed rather than added / changed
+
 ## 0.4.0 2018-04-25
 
 - move to global installation - requires removal of previous individual repo copies

--- a/diffcheck/diffcheck.go
+++ b/diffcheck/diffcheck.go
@@ -167,6 +167,11 @@ func checkLineBytes(line []byte, position int) (bool, []Warning) {
 
 	warnings := []Warning{}
 
+	// Check if it's a removed line - we don't care if it is
+	if bytes.HasPrefix(line, []byte(`-`)) {
+		return false, nil
+	}
+
 	// Normal line rulesets
 	for _, rule := range rule.Sets["line"] {
 		if rule.Regex.Match(line) {

--- a/diffcheck/diffcheck_test.go
+++ b/diffcheck/diffcheck_test.go
@@ -81,6 +81,22 @@ func shouldEqualInt(field string, got, expected int, t *testing.T) {
 
 var testCases = []testCase{
 	testCase{
+		Name:            "a file where sensitive lines were removed",
+		OK:              true,
+		ExpectedReports: nil,
+		Patch: []byte(`
+diff --git a/do.txt b/do.txt
+index 782d690..e69de29 100644
+--- a/do.txt
++++ b/do.txt
+@@ -1,3 +0,0 @@
+------BEGIN CERTIFICATE-----
+-cdcdcds
+------END CERTIFICATE-----
+\ No newline at end of file
+			`),
+	},
+	testCase{
 		Name:            "a totally fine file",
 		OK:              true,
 		ExpectedReports: nil,


### PR DESCRIPTION
Causes line check to ignore any line in a patch that is being removed rather than added - no need to flag when a potential secret is being _removed_