### PR TITLE
Update checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - fix #8 ignore lines in a patch that are being removed rather than added / changed
 - adds `-version` option to display the current cli version
+- fix #18 add basic version check
 
 ## 0.4.0 2018-04-25
 

--- a/cmd/pre-commit/main.go
+++ b/cmd/pre-commit/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,13 +21,42 @@ const (
 	rejected = 1
 )
 
-var (
-	target = flag.String("p", "", "(optional) path to repository")
-)
+// Repository defines the github repo where the source code is located
+const Repository = "ONSdigital/git-diff-check"
+
+var target = flag.String("p", "", "(optional) path to repository")
+var showVersion bool
+var showHelp bool
+
+func init() {
+	flag.BoolVar(&showVersion, "version", false, "show current version")
+	flag.BoolVar(&showHelp, "help", false, "show usage")
+}
+
+// Version is injected at build time
+var Version string
 
 func main() {
 
 	flag.Parse()
+
+	if showHelp {
+		flag.PrintDefaults()
+		os.Exit(0)
+	}
+
+	if showVersion {
+		if len(Version) == 0 {
+			fmt.Println(errors.New("No version set in binary! You may have a broken release"))
+			os.Exit(1)
+		}
+		fmt.Println(Version)
+		os.Exit(0)
+	}
+
+	// Attempt to check for a new version and inform the user if this is so.
+	// If we can't connect or get the version for some reason then this is non-fatal
+	versionCheck()
 
 	if *target == "" {
 		*target = "."
@@ -85,4 +118,46 @@ func main() {
 	}
 	fmt.Println("If you're VERY SURE these files are ok, rerun commit with --no-verify")
 	os.Exit(rejected)
+}
+
+// VersionResponse is the response from the github verson call
+type VersionResponse struct {
+	TagName string `json:"tag_name"`
+}
+
+func versionCheck() bool {
+
+	// TODO
+	// Set default client timeouts etc
+
+	resp, err := http.Get("https://api.github.com/repos/" + Repository + "/releases/latest")
+	if err != nil {
+		fmt.Println(errors.New("Failed to check for new versions" + err.Error()))
+		return false
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(errors.New("Failed to read response from version check" + err.Error()))
+		return false
+	}
+
+	var v VersionResponse
+	err = json.Unmarshal(body, &v)
+	if err != nil {
+		fmt.Println(errors.New("Failed to read response from version check" + err.Error()))
+		return false
+	}
+
+	if len(v.TagName) == 0 {
+		fmt.Println(errors.New("Failed to parse version from github response"))
+		return false
+	}
+
+	if v.TagName != Version {
+		fmt.Printf("\n** Precommit: New version %s available (installed %s) **\n\n", v.TagName, Version)
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
- fix #8 ignore lines in a patch that are being removed rather than added / changed
- adds `-version` option to display the current cli version
- fix #18 add basic version check