### PR TITLE
Added configuration yaml so can be used with pre-commit framework

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+- id: git-diff-check
+  name: ONS git-diff-check
+  description: This hook runs ONSDigital/git-diff-check
+  entry: pre-commit
+  language: golang 


### PR DESCRIPTION
Have added the configuration YAML needed for pre-commit (https://pre-commit.com) to install this as a hook.

Pre-commit uses the yaml to define the hook and from this knows to do `go get` to pull a local copy of the repo down,  it then installs `pre-commit` command built from git-diff-check as an entry point. 

Have tested against my own fork with this change made - https://github.com/bitmonkey/git-diff-check

Reason for doing this is so that I can use git-diff-check in my teams new docker based development template so that git-diff-check gets run as a pre-commit hook along with linting, source formatting and all that other good stuff - https://github.com/ONSdigital/es-lambda-dev-template.
